### PR TITLE
Initial commit / v 1.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+#
+# Exclude these files from release archives.
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/.github/ export-ignore
+/Test/ export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,9 @@
+<!--
+This repository is only for the PHPCompatibilityPasswordCompat ruleset, which prevents false positives from the PHPCompatibility standard by excluding the poly-fills which are provided by ircmaxell's password_compat library.
+
+If your issue is related to the PHPCompatibility sniffs, please open an issue in the PHPCompatibility repository: https://github.com/PHPCompatibility/PHPCompatibility/issues
+
+Before opening a new issue, please search for your issue to prevent opening a duplicate. If there is already an open issue, please leave a comment there.
+
+Thanks!
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,48 @@
+sudo: false
+
+dist: trusty
+
+cache:
+  apt: true
+
+language: php
+
+## Cache composer downloads.
+cache:
+  directories:
+    - $HOME/.cache/composer/files
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.2
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
+    - php: 5.4
+
+before_install:
+  # Speed up build time by disabling Xdebug when its not needed.
+  - if [[ $COVERALLS_VERSION == "notset" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
+  - export XMLLINT_INDENT="    "
+  - composer install
+  - vendor/bin/phpcs -i
+
+script:
+  - |
+    if [[ $TRAVIS_PHP_VERSION == "7.2" ]]; then
+      # Validate the xml file.
+      # @link http://xmlsoft.org/xmllint.html
+      xmllint --noout ./*/ruleset.xml
+
+      # Check the code-style consistency of the xml file.
+      diff -B ./PHPCompatibilityPasswordCompat/ruleset.xml <(xmllint --format "./PHPCompatibilityPasswordCompat/ruleset.xml")
+    fi
+
+  # Test the ruleset.
+  - vendor/bin/phpcs ./Test/PasswordCompatTest.php --standard=PHPCompatibilityPasswordCompat --runtime-set testVersion 5.4
+
+  # Validate the composer.json file.
+  # @link https://getcomposer.org/doc/03-cli.md#validate
+  - composer validate --no-check-all --strict

--- a/PHPCompatibilityPasswordCompat/ruleset.xml
+++ b/PHPCompatibilityPasswordCompat/ruleset.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCompatibilityPasswordCompat">
+    <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by ircmaxell's password_compat library.</description>
+
+    <rule ref="PHPCompatibility">
+        <!-- https://github.com/ircmaxell/password_compat/blob/master/lib/password.php -->
+        <exclude name="PHPCompatibility.Constants.NewConstants.password_bcryptFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.password_bcrypt_default_costFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.password_defaultFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.password_get_infoFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.password_hashFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.password_needs_rehashFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.password_verifyFound"/>
+    </rule>
+
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,91 @@
+[![Latest Stable Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-passwordcompat/v/stable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-passwordcompat)
+[![Latest Unstable Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-passwordcompat/v/unstable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-passwordcompat)
+[![License](https://poser.pugx.org/phpcompatibility/phpcompatibility-passwordcompat/license.png)](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat/blob/master/LICENSE)
+[![Build Status](https://travis-ci.org/PHPCompatibility/PHPCompatibilityPasswordCompat.svg?branch=master)](https://travis-ci.org/PHPCompatibility/PHPCompatibilityPasswordCompat)
+
 # PHPCompatibilityPasswordCompat
-PHPCompatibility ruleset which can be included in projects using @ircmaxell's PasswordCompat polyfill library
+
+Using PHPCompatibilityPasswordCompat, you can analyse the codebase of a project using using @[ircmaxell](https://github.com/ircmaxell/)'s [password_compat](https://github.com/ircmaxell/password_compat)  polyfill library, for PHP cross-version compatibility.
+
+
+## What's in this repo ?
+
+A rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the @ircmaxell's [password_compat](https://github.com/ircmaxell/password_compat)  polyfill library.
+
+This ruleset prevents false positives from the [PHPCompatibility standard](https://github.com/PHPCompatibility/PHPCompatibility) by excluding back-fills and poly-fills which are provided by the `random_compat` library.
+
+
+## Requirements
+
+* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
+    * PHP 5.3+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 2.3.0+.
+    * PHP 5.4+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 3.0.2+.
+
+    Use the latest stable release of PHP_CodeSniffer for the best results.
+    The minimum _recommended_ version of PHP_CodeSniffer is version 2.6.0.
+* [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) 9.0.0+.
+
+
+## Installation instructions
+
+The only supported installation method is via [Composer](https://getcomposer.org/).
+
+If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
+```bash
+composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.4.4 phpcompatibility/phpcompatibility-passwordcompat:*
+composer install
+```
+
+If you already have a Composer PHP_CodeSniffer plugin installed, run:
+```bash
+composer require --dev phpcompatibility/phpcompatibility-passwordcompat:*
+composer install
+```
+
+Next, run:
+```bash
+vendor/bin/phpcs -i
+```
+If all went well, you will now see that the `PHPCompatibility` and `PHPCompatibilityPasswordCompat` standards are installed for PHP_CodeSniffer.
+
+
+## How to use
+
+Now you can use the following command to inspect the code in your project for PHP cross-version compatibility:
+```bash
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat
+```
+
+By default, you will only receive notifications about deprecated and/or removed PHP features.
+
+To get the most out of the PHPCompatibilityPasswordCompat standard, you should specify a `testVersion` to check against. That will enable the checks for both deprecated/removed PHP features as well as the detection of code using new PHP features.
+
+For example:
+```bash
+# For a project which should be compatible with PHP 5.3 up to and including PHP 7.0:
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat --runtime-set testVersion 5.3-7.0
+
+# For a project which should be compatible with PHP 5.4 and higher:
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat --runtime-set testVersion 5.4-
+```
+
+For more detailed information about setting the `testVersion`, see the README of the generic [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions) standard.
+
+
+### Testing PHP files only
+
+By default PHP_CodeSniffer will analyse PHP, JavaScript and CSS files. As the PHPCompatibility sniffs only target PHP code, you can make the run slightly faster by telling PHP_CodeSniffer to only check PHP files, like so:
+```bash
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat --extensions=php --runtime-set testVersion 5.3-
+```
+
+## License
+
+All code within the PHPCompatibility organisation is released under the GNU Lesser General Public License (LGPL). For more information, visit https://www.gnu.org/copyleft/lesser.html
+
+
+## Changelog
+
+### 1.0.0 - 2018-10-07
+
+Initial release of the PHPCompatibilityPasswordCompat ruleset.

--- a/Test/PasswordCompatTest.php
+++ b/Test/PasswordCompatTest.php
@@ -1,0 +1,10 @@
+<?php
+/*
+ * Test file to run PHP_CodeSniffer against to make sure the polyfills are correctly excluded.
+ */
+$a = password_get_info( $hash );
+$a = password_hash( $password, PASSWORD_BCRYPT, $options );
+$a = password_needs_rehash( $hash, PASSWORD_DEFAULT, $options );
+$a = password_verify( $password, $hash );
+
+echo PASSWORD_BCRYPT_DEFAULT_COST;

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,31 @@
+{
+  "name" : "phpcompatibility/phpcompatibility-passwordcompat",
+  "description" : "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by ircmaxell's password_compat library.",
+  "type" : "phpcodesniffer-standard",
+  "keywords" : [ "compatibility", "phpcs", "standards", "password_compat", "polyfill" ],
+  "homepage" : "http://phpcompatibility.com/",
+  "license" : "LGPL-3.0-or-later",
+  "authors" : [ {
+    "name" : "Wim Godden",
+    "role" : "lead"
+  },
+  {
+    "name" : "Juliette Reinders Folmer",
+    "role" : "lead"
+  } ],
+  "support" : {
+    "issues" : "https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat/issues",
+    "source" : "https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat"
+  },
+  "require" : {
+    "phpcompatibility/php-compatibility" : "^9.0"
+  },
+  "require-dev" : {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+  },
+  "suggest" : {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+    "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+  },
+  "prefer-stable" : true
+}


### PR DESCRIPTION
:warning: **IMPORTANT** :warning:
The build for this PR will not pass until PHPCompatibility 9.0.0 has been released.  This PR should not be merged until then. 

---

- Adds the `password_compat` specific PHPCompatibility ruleset.
- Adds README with basic installation and usage instructions.
- Adds `composer.json` file which requires the PHPCompatibility standard and `dev` requires the DealerDirect PHPCS Composer plugin to install the standards for testing.
- Adds a minimal PHP file to test the ruleset against.
- Adds a Travis config to test the ruleset, validate the ruleset XML and the Composer configuration on each update.
- Adds `.gitignore` to ignore the `vendor` directory and the `composer.lock` file.
- Adds `.gitattributes` to keep release archives clean.
- Adds `.github/issue_template.md` to try and prevent issues related to the generic PHPCompatibility standard from being opened in this repository.