### PR TITLE
Ruleset: prevent false positives on polyfill code

### DIFF
--- a/PHPCompatibilityPasswordCompat/ruleset.xml
+++ b/PHPCompatibilityPasswordCompat/ruleset.xml
@@ -13,4 +13,15 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.password_verifyFound"/>
     </rule>
 
+    <!-- Prevent false positives being thrown when run over the code of password_compat itself. -->
+    <rule ref="PHPCompatibility.Constants.RemovedConstants.mcrypt_dev_urandomDeprecatedRemoved">
+        <exclude-pattern>/password[-_]compat/lib/password\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Extensions.RemovedExtensions.mcryptDeprecatedRemoved">
+        <exclude-pattern>/password[-_]compat/lib/password\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_create_ivDeprecatedRemoved">
+        <exclude-pattern>/password[-_]compat/lib/password\.php$</exclude-pattern>
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
When [notifying the polyfill repos](https://github.com/ircmaxell/password_compat/issues/107) about the polyfill rulesets, I came across [this issue](https://github.com/ircmaxell/password_compat/issues/106) and figured we could fix that.

---

When `PHPCompatibility(PasswordCompat)` is run over the code in the `password_compat` repo itself, it will detect some non-issues.

```
FILE: password_compat\lib\password.php
------------------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 1 LINE
------------------------------------------------------------------------------------------
 105 | ERROR | Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2;
     |       | Use openssl (preferred) or pecl/mcrypt once available instead
     |       | (PHPCompatibility.Extensions.RemovedExtensions.mcryptDeprecatedRemoved)
 105 | ERROR | Function mcrypt_create_iv() is deprecated since PHP 7.1 and removed since
     |       | PHP 7.2; Use random_bytes() or OpenSSL instead
     |       | (PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_create_ivDeprecatedRemoved)
 105 | ERROR | The constant "MCRYPT_DEV_URANDOM" is deprecated since PHP 7.1 and removed
     |       | since PHP 7.2
     |       | (PHPCompatibility.Constants.RemovedConstants.mcrypt_dev_urandomDeprecatedRemoved)
------------------------------------------------------------------------------------------
```

The code in the `lib/password.php` file is all wrapped within `defined()` and/or `function_exists()` conditions and will never be executed on PHP 5.5+ as the functionality being polyfilled is by then provided natively by PHP.

This simple change prevents these non-issues from being reported.

This fix does rely on people having installed the code in a directory called `password_compat` or, for composer installs `password-compat`.