### PR TITLE
Switch to PHPCSStandards/PHP_CodeSniffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This ruleset prevents false positives from the [PHPCompatibility standard](https
 
 ## Requirements
 
-* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
-    * PHP 5.3+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 2.3.0+.
-    * PHP 5.4+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 3.0.2+.
+* [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
+    * PHP 5.3+ for use with [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) 2.3.0+.
+    * PHP 5.4+ for use with [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) 3.0.2+.
 
     Use the latest stable release of PHP_CodeSniffer for the best results.
     The minimum _recommended_ version of PHP_CodeSniffer is version 2.6.0.


### PR DESCRIPTION
⚠️  **_This is a DRAFT PR on purpose as it references releases which have not yet been tagged. Once the PHPCS 3.8.0 tag is available ~~(which contains the Composer `replace` directive)~~, this can/should be merged ~~and released ASAP~~._** ⚠️ 

---

The Squizlabs repo has been abandoned. The project continues in a fork in the PHPCSStandards organisation.

~~Includes updating the dev required version of the Composer plugin, which should make sure that this repo already switches over to using the PHPCSStandards version of PHPCS.~~

~~Includes updating the suggested version of the Composer plugin to the version which made the same change.~~

**Update**: The Composer package name will not change, so while this PR should still be merged at our convenience (after the 3.8.0 release, expected this Friday), we will not need to do a release to unblock end-users.

Ref:
* squizlabs/PHP_CodeSniffer#3932