### PR TITLE
README: fix broken badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Latest Stable Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-passwordcompat/v/stable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-passwordcompat)
-[![Latest Unstable Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-passwordcompat/v/unstable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-passwordcompat)
-[![License](https://poser.pugx.org/phpcompatibility/phpcompatibility-passwordcompat/license.png)](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat/blob/master/LICENSE)
-[![Build Status](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat/workflows/CI/badge.svg?branch=master)](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat/actions)
+[![Latest Stable Version](https://img.shields.io/packagist/v/phpcompatibility/phpcompatibility-passwordcompat?label=stable)](https://packagist.org/packages/phpcompatibility/phpcompatibility-passwordcompat)
+[![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)](https://packagist.org/packages/phpcompatibility/phpcompatibility-passwordcompat)
+[![License](https://img.shields.io/github/license/PHPCompatibility/PHPCompatibilityPasswordCompat?color=00a7a7)](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat/blob/master/LICENSE)
+[![Build Status](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat/actions/workflows/ci.yml)
 
 # PHPCompatibilityPasswordCompat
 


### PR DESCRIPTION
* The badges from poser do not seem to work anymore, so replacing these with shields.io.
* Additionally, the GH CI status badge currently displays "no status", as apparently GH changed the badge URL format (yet again) without notice.

![image](https://github.com/user-attachments/assets/bb1638ed-be60-4ac7-8252-081753e55900)

Fixed now.