### PR TITLE
Ruleset file: add schema tags to the ruleset

### DIFF
--- a/PHPCompatibilityPasswordCompat/ruleset.xml
+++ b/PHPCompatibilityPasswordCompat/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCompatibilityPasswordCompat">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilityPasswordCompat" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by ircmaxell's password_compat library.</description>
 
     <rule ref="PHPCompatibility">


### PR DESCRIPTION
As of PHPCS 3.2.0, PHPCS offers an XSD schema for rulesets which defines what can be used in the XML ruleset file.

As of a couple of weeks ago, the XSD schema is now available via permalinks.

This commit adds the relevant schema tags to the PHPCS Ruleset file(s).

Refs:
* squizlabs/PHP_CodeSniffer#1433
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.2.0
* PHPCSStandards/PHP_CodeSniffer#1094
* https://github.com/PHPCSStandards/schema.phpcodesniffer.com