### PR TITLE
Version 2.0.0-alpha1 / Update for PHPCompatibility 10.0.0-alpha1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
         include:
           - php: '7.4'
-            phpcompat: 'dev-develop as 9.99.99'
+            phpcompat: 'dev-develop as 10.99.99'
             experimental: true
 
     name: "Test: PHP ${{ matrix.php }} - PHPCompat ${{ matrix.phpcompat }}"
@@ -103,10 +103,15 @@ jobs:
 
       # Make sure that known polyfills don't trigger any errors.
       - name: Test the ruleset
-        run: |
-          vendor/bin/phpcs -ps ./Test/PasswordCompatTest.php --standard=PHPCompatibilityPasswordCompat --runtime-set testVersion 5.4-
+        run: >
+          vendor/bin/phpcs -ps ./Test/PasswordCompatTest.php --standard=PHPCompatibilityPasswordCompat
+          --exclude=PHPCompatibility.Upgrade.LowPHP
+          --runtime-set testVersion 5.4-
 
       # Check that the ruleset doesn't throw unnecessary errors for the compat library itself.
       - name: Test running against the polyfills
-        run: |
-          vendor/bin/phpcs -ps ./vendor/ircmaxell/ --standard=PHPCompatibilityPasswordCompat --runtime-set testVersion 5.4- --ignore=/password-compat/test/*
+        run: >
+          vendor/bin/phpcs -ps ./vendor/ircmaxell/ --standard=PHPCompatibilityPasswordCompat
+          --exclude=PHPCompatibility.Upgrade.LowPHP
+          --ignore=/password-compat/test/*
+          --runtime-set testVersion 5.4-

--- a/README.md
+++ b/README.md
@@ -1,44 +1,47 @@
 # PHPCompatibilityPasswordCompat
 
-[![Latest Stable Version](https://img.shields.io/packagist/v/phpcompatibility/phpcompatibility-passwordcompat?label=stable)](https://packagist.org/packages/phpcompatibility/phpcompatibility-passwordcompat)
-[![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)](https://packagist.org/packages/phpcompatibility/phpcompatibility-passwordcompat)
+[![Latest Stable Version](https://img.shields.io/packagist/v/phpcompatibility/phpcompatibility-passwordcompat?label=stable)][packagist]
+[![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)][packagist]
 [![License](https://img.shields.io/github/license/PHPCompatibility/PHPCompatibilityPasswordCompat?color=00a7a7)](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat/blob/master/LICENSE)
 [![Build Status](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat/actions/workflows/ci.yml)
 
-Using PHPCompatibilityPasswordCompat, you can analyse the codebase of a project using using @[ircmaxell](https://github.com/ircmaxell/)'s [password_compat](https://github.com/ircmaxell/password_compat)  polyfill library, for PHP cross-version compatibility.
+Using PHPCompatibilityPasswordCompat, you can analyse the codebase of a project using [@ircmaxell][ircmaxell]'s [password_compat] polyfill library, for PHP cross-version compatibility.
 
 
 ## What's in this repo ?
 
-A rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the @ircmaxell's [password_compat](https://github.com/ircmaxell/password_compat)  polyfill library.
+A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by [@ircmaxell][ircmaxell]'s [password_compat] polyfill library.
 
-This ruleset prevents false positives from the [PHPCompatibility standard](https://github.com/PHPCompatibility/PHPCompatibility) by excluding back-fills and poly-fills which are provided by the `random_compat` library.
+This ruleset prevents false positives from the [PHPCompatibility standard][PHPCompatibility] by excluding back-fills and polyfills which are provided by the `password_compat` library.
+
+
+## Funding
+
+**This project needs funding.**
+
+The project team has spend thousands of hours creating and maintaining the PHPCompatibility packages. This is unsustainable without funding.
+
+If you use PHPCompatibility, please fund this work by setting up a monthly contribution to the [PHP_CodeSniffer Open Collective].
 
 
 ## Requirements
 
-* [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
-    - PHP 5.3+ for use with [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) 2.3.0+.
-    - PHP 5.4+ for use with [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) 3.0.2+.
-
+* PHP > 5.4
+* [PHP_CodeSniffer] >= 3.13.3.
     Use the latest stable release of PHP_CodeSniffer for the best results.
-    The minimum _recommended_ version of PHP_CodeSniffer is version 2.6.0.
-* [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) 9.0.0+.
+* [PHPCompatibility] 10.0.0+.
 
 
 ## Installation instructions
 
-The only supported installation method is via [Composer](https://getcomposer.org/).
+The only supported installation method is via [Composer].
 
-If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
+[Composer] will automatically install the project dependencies and register the external rulesets with PHP_CodeSniffer using the [Composer PHPCS plugin].
+
+Run the following from the root of your project:
 ```bash
 composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-composer require --dev dealerdirect/phpcodesniffer-composer-installer:"^0.7" phpcompatibility/phpcompatibility-passwordcompat:"*"
-```
-
-If you already have a Composer PHP_CodeSniffer plugin installed, run:
-```bash
-composer require --dev phpcompatibility/phpcompatibility-passwordcompat:"*"
+composer require --dev phpcompatibility/phpcompatibility-passwordcompat:"^2.0@dev"
 ```
 
 Next, run:
@@ -48,11 +51,22 @@ vendor/bin/phpcs -i
 If all went well, you will now see that the `PHPCompatibility` and `PHPCompatibilityPasswordCompat` standards are installed for PHP_CodeSniffer.
 
 
+## Upgrade instructions
+
+To upgrade this package, run the following command:
+```bash
+composer update --dev phpcompatibility/phpcompatibility-passwordcompat --with-dependencies
+```
+
+> [!TIP]
+> If you have a _root_ requirement in your project for one of the packages used by this project, you may need to update with `--with-all-dependencies` instead.
+
+
 ## How to use
 
-Now you can use the following command to inspect the code in your project for PHP cross-version compatibility:
+You can now use the following command to inspect the code in your project for PHP cross-version compatibility:
 ```bash
-./vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat
+vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat
 ```
 
 By default, you will only receive notifications about deprecated and/or removed PHP features.
@@ -62,22 +76,33 @@ To get the most out of the PHPCompatibilityPasswordCompat standard, you should s
 For example:
 ```bash
 # For a project which should be compatible with PHP 5.3 up to and including PHP 7.0:
-./vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat --runtime-set testVersion 5.3-7.0
+vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat --runtime-set testVersion 5.3-7.0
 
 # For a project which should be compatible with PHP 5.4 and higher:
-./vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat --runtime-set testVersion 5.4-
+vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat --runtime-set testVersion 5.4-
 ```
 
-For more detailed information about setting the `testVersion`, see the README of the generic [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions) standard.
+For more detailed information about setting the `testVersion`, see the README of the generic [PHPCompatibility][PHPCompatibility-testVersion] standard.
 
 
 ### Testing PHP files only
 
-By default PHP_CodeSniffer will analyse PHP, JavaScript and CSS files. As the PHPCompatibility sniffs only target PHP code, you can make the run slightly faster by telling PHP_CodeSniffer to only check PHP files, like so:
+By default PHP_CodeSniffer < 4.0 will analyse PHP, JavaScript and CSS files. As the PHPCompatibility sniffs only target PHP code, you can make the run slightly faster by telling PHP_CodeSniffer to only check PHP files, like so:
 ```bash
-./vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat --extensions=php --runtime-set testVersion 5.3-
+vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat --extensions=php --runtime-set testVersion 5.3-
 ```
 
 ## License
 
-All code within the PHPCompatibility organisation is released under the GNU Lesser General Public License (LGPL). For more information, visit <https://www.gnu.org/licenses/lgpl-3.0.html>
+All code within the PHPCompatibility organisation is released under the GNU Lesser General Public License (LGPL). For more information, visit <https://www.gnu.org/licenses/lgpl-3.0.html>.
+
+
+[packagist]:                       https://packagist.org/packages/phpcompatibility/phpcompatibility-passwordcompat
+[Composer]:                        https://getcomposer.org/
+[Composer PHPCS plugin]:           https://github.com/PHPCSStandards/composer-installer/
+[ircmaxell]:                       https://github.com/ircmaxell/
+[password_compat]:                 https://github.com/ircmaxell/password_compat
+[PHP_CodeSniffer]:                 https://github.com/PHPCSStandards/PHP_CodeSniffer
+[PHP_CodeSniffer Open Collective]: https://opencollective.com/php_codesniffer
+[PHPCompatibility]:                https://github.com/PHPCompatibility/PHPCompatibility
+[PHPCompatibility-testVersion]:    https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions

--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,10 @@
     "lock": false
   },
   "require" : {
-    "phpcompatibility/php-compatibility" : "^9.0"
+    "phpcompatibility/php-compatibility" : "^10.0@dev"
   },
   "require-dev" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
     "ircmaxell/password-compat": "dev-master"
-  },
-  "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
-    "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
   "prefer-stable" : true
 }


### PR DESCRIPTION
This update accounts for the following changes:
* Ruleset:
    **_No ruleset updates needed._**
* Composer:
    - Update the version for the PHPCompatibility dependency.
        The `@dev` version number suffix should ensure that the PHPCompatibility 10.0.0-alpha1 version can be installed, even if the project minimum stability does not specifically allow for dev versions.
    - Remove the DealerDirect Composer PHPCS plugin dependency.
        This plugin will now automatically be installed as it is a dependency of PHPCSUtils and therefore of PHPCompatibility itself.
        Not having it set as an explicit dependency here, will prevent potential future conflicts with the supported versions of the plugin.
    - Removed the `suggest` section.
        The DealerDirect plugin no longer needs to be suggested and after two years, people should have gotten the message about using the `roave/security-advisories`.
* Readme:
    - Updated the minimum PHP and PHPCS requirements.
    - Updated the installation instructions for the 2.0.0-alpha1 release (being a dev release).
    - Updated the installation instructions to no longer mention adding a Composer plugin to sort out the PHPCS `installed_paths`.
    - Added upgrade instructions.
    - Added section about funding.
    - Use link list for links used multiple times.
    - Minor other tweaks after critical read-through of the README.
* CI:
    - Continue testing against `dev-develop`.
    - Prevent builds failing on low PHP versions on the recommendation to use a more recent PHP version.
